### PR TITLE
Fixed all shapes per customers requests.

### DIFF
--- a/client/src/components/VideoElement.tsx
+++ b/client/src/components/VideoElement.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 
 import Konva from 'konva';
-import { Stage, Layer, Circle, Rect, Arrow } from 'react-konva';
+import { Stage, Layer, Circle, Rect, Arrow, Ellipse } from 'react-konva';
 
 import { v4 as uuidv4 } from 'uuid';
 import { Button } from '@/components/ui/button';
@@ -41,7 +41,8 @@ type CircleShape = {
   // Center of the circle
   x: number;
   y: number;
-  radius: number;
+  radiusX: number;
+  radiusY: number;
   stroke: string;
   strokeWidth: number;
 };
@@ -88,13 +89,11 @@ interface ExistingShapesProps {
   getStagePointFromOriginalVideoCoords: (
     videoCoords: { x: number; y: number } | null | undefined
   ) => { x: number; y: number } | null;
-  scale: number;
 }
 
 const ExistingShapes: React.FC<ExistingShapesProps> = ({
   shapes,
   getStagePointFromOriginalVideoCoords,
-  scale,
 }) => {
   return (
     <>
@@ -107,35 +106,55 @@ const ExistingShapes: React.FC<ExistingShapesProps> = ({
           strokeWidth: shape.strokeWidth,
         };
         if (shape.type === 'rect') {
-          const centerCoordinate = getStagePointFromOriginalVideoCoords({
-            x: shape.x,
-            y: shape.y,
-          });
-          if (!centerCoordinate) return null;
+          // Stored shape has video center (shape.x, shape.y) and video dimensions (shape.width, shape.height)
+          const videoW = shape.width;
+          const videoH = shape.height;
+
+          // Calculate video corner points
+          const videoTopLeft = { x: shape.x, y: shape.y };
+          const videoBottomRight = { x: shape.x + videoW, y: shape.y + videoH };
+
+          // Convert video corners to stage coordinates
+          const stageTopLeft =
+            getStagePointFromOriginalVideoCoords(videoTopLeft);
+          const stageBottomRight =
+            getStagePointFromOriginalVideoCoords(videoBottomRight);
+
+          if (!stageTopLeft || !stageBottomRight) return null; // Handle conversion failure
+
+          // Use stage coordinates for Konva Rect props
           return (
             <Rect
               key={key} // Pass key directly
               {...otherCommonProps} // Spread the rest
-              x={centerCoordinate.x - shape.width / 2}
-              y={centerCoordinate.y - shape.height / 2}
-              width={shape.width}
-              height={shape.height}
+              x={stageTopLeft.x} // Use converted stage top-left X
+              y={stageTopLeft.y} // Use converted stage top-left Y
+              width={stageBottomRight.x - stageTopLeft.x} // Calculate stage width from converted points
+              height={stageBottomRight.y - stageTopLeft.y} // Calculate stage height from converted points
             />
           );
         }
         if (shape.type === 'circle') {
-          const stagePoint = getStagePointFromOriginalVideoCoords({
+          const stageCenter = getStagePointFromOriginalVideoCoords({
             x: shape.x,
             y: shape.y,
           });
-          if (!stagePoint) return null;
+          if (!stageCenter) return null;
+
+          const stageBottomRight = getStagePointFromOriginalVideoCoords({
+            x: shape.x + shape.radiusX,
+            y: shape.y + shape.radiusY,
+          });
+          if (!stageBottomRight) return null;
+
           return (
-            <Circle
+            <Ellipse
               key={key} // Pass key directly
               {...otherCommonProps} // Spread the rest
-              x={stagePoint.x}
-              y={stagePoint.y}
-              radius={shape.radius * scale}
+              x={stageCenter.x}
+              y={stageCenter.y}
+              radiusX={stageBottomRight.x - stageCenter.x}
+              radiusY={stageBottomRight.y - stageCenter.y}
             />
           );
         }
@@ -173,25 +192,13 @@ const ExistingShapes: React.FC<ExistingShapesProps> = ({
 
 interface NewShapePreviewProps {
   newShape: ShapeData | null;
-  getStagePointFromOriginalVideoCoords: (
-    videoCoords: { x: number; y: number } | null | undefined
-  ) => { x: number; y: number } | null;
-  scale: number;
 }
 
-const NewShapePreview: React.FC<NewShapePreviewProps> = ({
-  newShape,
-  getStagePointFromOriginalVideoCoords,
-  scale,
-}) => {
+const NewShapePreview: React.FC<NewShapePreviewProps> = ({ newShape }) => {
   if (!newShape) return null;
-
+  // These coordinates are all in the stages coordinates system, and will be transformed on mouse release.
+  // We need to convert them to the video coordinates system when the shape is added to the shapes array.
   if (newShape.type === 'rect') {
-    const stagePoint = getStagePointFromOriginalVideoCoords({
-      x: newShape.x,
-      y: newShape.y,
-    });
-    if (!stagePoint) return null;
     return (
       <Rect
         x={newShape.x}
@@ -205,16 +212,12 @@ const NewShapePreview: React.FC<NewShapePreviewProps> = ({
     );
   }
   if (newShape.type === 'circle') {
-    const stagePoint = getStagePointFromOriginalVideoCoords({
-      x: newShape.x,
-      y: newShape.y,
-    });
-    if (!stagePoint) return null;
     return (
-      <Circle
-        x={stagePoint.x}
-        y={stagePoint.y}
-        radius={newShape.radius * scale}
+      <Ellipse
+        x={newShape.x}
+        y={newShape.y}
+        radiusX={newShape.radiusX}
+        radiusY={newShape.radiusY}
         stroke={newShape.stroke}
         strokeWidth={newShape.strokeWidth}
         dash={[5, 5]}
@@ -222,20 +225,15 @@ const NewShapePreview: React.FC<NewShapePreviewProps> = ({
     );
   }
   if (newShape.type === 'arrow') {
-    const stagePoint = getStagePointFromOriginalVideoCoords({
-      x: newShape.points[0],
-      y: newShape.points[1],
-    });
-
-    const stagePoint2 = getStagePointFromOriginalVideoCoords({
-      x: newShape.points[2],
-      y: newShape.points[3],
-    });
-    if (!stagePoint || !stagePoint2) return null;
     return (
       <Arrow
         {...newShape}
-        points={[stagePoint.x, stagePoint.y, stagePoint2.x, stagePoint2.y]}
+        points={[
+          newShape.points[0],
+          newShape.points[1],
+          newShape.points[2],
+          newShape.points[3],
+        ]}
         pointerLength={10}
         pointerWidth={10}
         dash={[5, 5]}
@@ -535,11 +533,8 @@ const VideoElement = forwardRef<VideoElementRef, VideoElementProps>(
 
       setSelectedId(null); // Deselect any selected shape when starting a new one
 
-      const videoCoords = getOriginalVideoCoordsFromStagePoint(stagePoint);
-      if (!videoCoords) return;
-
-      setDrawStartX(videoCoords.x);
-      setDrawStartY(videoCoords.y);
+      setDrawStartX(stagePoint.x);
+      setDrawStartY(stagePoint.y);
       const id = uuidv4();
 
       if (currentShapeType === 'rect') {
@@ -558,9 +553,10 @@ const VideoElement = forwardRef<VideoElementRef, VideoElementProps>(
         setNewShape({
           id,
           type: 'circle',
-          x: videoCoords.x,
-          y: videoCoords.y,
-          radius: 0,
+          x: stagePoint.x,
+          y: stagePoint.y,
+          radiusX: 0,
+          radiusY: 0,
           stroke: 'red',
           strokeWidth: 4,
         });
@@ -569,12 +565,12 @@ const VideoElement = forwardRef<VideoElementRef, VideoElementProps>(
         setNewShape({
           id,
           type: 'arrow',
-          points: [
-            videoCoords.x,
-            videoCoords.y,
-            videoCoords.x,
-            videoCoords.y,
-          ] as [number, number, number, number],
+          points: [stagePoint.x, stagePoint.y, stagePoint.x, stagePoint.y] as [
+            number,
+            number,
+            number,
+            number,
+          ],
           stroke: 'red',
           strokeWidth: 4,
         });
@@ -646,10 +642,6 @@ const VideoElement = forwardRef<VideoElementRef, VideoElementProps>(
       )
         return;
 
-      const videoCoords =
-        getOriginalVideoCoordsFromStagePoint(currentPointerPos);
-      if (!videoCoords) return;
-
       setNewShape((prev) => {
         if (!prev) return null;
 
@@ -667,21 +659,18 @@ const VideoElement = forwardRef<VideoElementRef, VideoElementProps>(
         }
         if (prev.type === 'circle') {
           // Calculate center and radius based on the two diagonal points
-          const x1 = drawStartX as number; // Use fixed start X
-          const y1 = drawStartY as number; // Use fixed start Y
-          const x2 = videoCoords.x;
-          const y2 = videoCoords.y;
-
-          const centerX = (x1 + x2) / 2;
-          const centerY = (y1 + y2) / 2;
-          const radius = Math.hypot(x2 - x1, y2 - y1) / 2;
+          const centerX = (drawStartX + currentPointerPos.x) / 2;
+          const centerY = (drawStartY + currentPointerPos.y) / 2;
+          const rX = Math.abs((currentPointerPos.x - drawStartX) / 2);
+          const rY = Math.abs((currentPointerPos.y - drawStartY) / 2);
 
           return {
             id: prev.id,
             type: 'circle',
             x: centerX, // Update x to be the calculated center
             y: centerY, // Update y to be the calculated center
-            radius,
+            radiusX: rX,
+            radiusY: rY,
             stroke: prev.stroke,
             strokeWidth: prev.strokeWidth,
           };
@@ -691,7 +680,7 @@ const VideoElement = forwardRef<VideoElementRef, VideoElementProps>(
           return {
             id: prev.id,
             type: 'arrow',
-            points: [x0, y0, videoCoords.x, videoCoords.y] as [
+            points: [x0, y0, currentPointerPos.x, currentPointerPos.y] as [
               number,
               number,
               number,
@@ -778,7 +767,8 @@ const VideoElement = forwardRef<VideoElementRef, VideoElementProps>(
           (Math.abs(shape.width) < 5 || Math.abs(shape.height) < 5)
         )
           isValidShape = false;
-        if (shape.type === 'circle' && shape.radius < 3) isValidShape = false;
+        if (shape.type === 'circle' && (shape.radiusX < 3 || shape.radiusY < 3))
+          isValidShape = false;
         if (
           shape.type === 'arrow' &&
           Math.hypot(
@@ -805,32 +795,61 @@ const VideoElement = forwardRef<VideoElementRef, VideoElementProps>(
             getOriginalVideoCoordsFromStagePoint(stageBottomRight);
 
           if (!videoTopLeft || !videoBottomRight) {
-            // If conversion fails, the shape is invalid
-            console.error(
-              'Failed to convert rectangle corners to video coordinates.'
-            );
             isValidShape = false;
           } else {
             // Calculate the width and height in the video coordinate system
             const videoWidth = Math.abs(videoBottomRight.x - videoTopLeft.x);
             const videoHeight = Math.abs(videoBottomRight.y - videoTopLeft.y);
 
-            // Re-validate the shape size based on video dimensions
-            if (videoWidth < 5 || videoHeight < 5) {
-              isValidShape = false;
-            }
+            // Update the shape properties to store the center coordinates
+            // and dimensions relative to the original video
+            shape.x = videoTopLeft.x;
+            shape.y = videoTopLeft.y;
+            shape.width = videoWidth;
+            shape.height = videoHeight;
+          }
+        }
+        if (shape.type === 'circle') {
+          // The 'shape' object currently holds stage coordinates with a top-left origin
+          // We need to convert these to video coordinates with a center origin.
 
-            // If the shape is still valid after size check
-            if (isValidShape) {
-              // Calculate the center point in the video coordinate system
-              const videoCenterX = (videoTopLeft.x + videoBottomRight.x) / 2;
-              const videoCenterY = (videoTopLeft.y + videoBottomRight.y) / 2;
+          const stageCenter = { x: shape.x, y: shape.y };
+          const stageBottomRight = {
+            x: shape.x + shape.radiusX,
+            y: shape.y + shape.radiusY,
+          };
 
-              // Update the shape properties to store the center coordinates
-              // and dimensions relative to the original video
-              shape.x = videoCenterX;
-              shape.y = videoCenterY;
-            }
+          const videoCenter = getOriginalVideoCoordsFromStagePoint(stageCenter);
+          const videoBottomRight =
+            getOriginalVideoCoordsFromStagePoint(stageBottomRight);
+
+          if (!videoCenter || !videoBottomRight) {
+            isValidShape = false;
+          } else {
+            const videoRadiusX = Math.abs(videoBottomRight.x - videoCenter.x);
+            const videoRadiusY = Math.abs(videoBottomRight.y - videoCenter.y);
+            shape.x = videoCenter.x;
+            shape.y = videoCenter.y;
+            shape.radiusX = videoRadiusX;
+            shape.radiusY = videoRadiusY;
+          }
+        }
+        if (shape.type === 'arrow') {
+          // Arrow positions are in the stage coordinates system.
+          // Tranform positions to the video coordinates system.
+          const stagePoint = { x: shape.points[0], y: shape.points[1] };
+          const stagePoint2 = { x: shape.points[2], y: shape.points[3] };
+          const videoPoint = getOriginalVideoCoordsFromStagePoint(stagePoint);
+          const videoPoint2 = getOriginalVideoCoordsFromStagePoint(stagePoint2);
+          if (!videoPoint || !videoPoint2) {
+            isValidShape = false;
+          } else {
+            shape.points = [
+              videoPoint.x,
+              videoPoint.y,
+              videoPoint2.x,
+              videoPoint2.y,
+            ];
           }
         }
 


### PR DESCRIPTION
Shapes now update to videocoordinates  on mouseUp only.
Circle changed to an ellipse. 

All shapes now maintain size and position relative to video.
Rectangle coordinates are saved as top left coordinates.
Eclipse coordinates center of circle.
Arrow coordinates arrow pointer and end of the line.