### PR TITLE
Remove unnecessary linker that causes macOS to not run

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -131,7 +131,6 @@ endif()
 target_link_libraries(server 
     mongoose 
     mongoose_includes
-    stdc++fs
     ${PLATFORM_SPECIFIC_LIBS}
     ${OpenCV_LIBS}
 )


### PR DESCRIPTION
Tog bort stdc++fs linker då det gjorde att macOS inte kunde makea servern.

Ska inte vara några problem då detta bara lades till för windows compatability